### PR TITLE
[#1] bug: fix script injection when head tag has whitespace or attributes

### DIFF
--- a/src/visitWithWebVitalsSnippet.js
+++ b/src/visitWithWebVitalsSnippet.js
@@ -3,7 +3,11 @@ const { WEB_VITALS_SNIPPET } = require("./constants");
 const visitWithWebVitalsSnippet = (url) => {
   cy.intercept(url, (req) => {
     req.continue((res) => {
-      res.send(res.body.replace("<head>", `<head>${WEB_VITALS_SNIPPET}`));
+      const body = res.body.replace(
+        /<head(>|.*?[^?]>)/g,
+        `<head$1${WEB_VITALS_SNIPPET}`
+      );
+      res.send(body);
     });
   });
 

--- a/src/visitWithWebVitalsSnippet.test.js
+++ b/src/visitWithWebVitalsSnippet.test.js
@@ -43,6 +43,27 @@ describe("visitWithWebVitalsSnippet", () => {
     });
   });
 
+  describe("irregular head tag intercept", () => {
+    const mockResponse = {
+      send: jest.fn(),
+      body: '<html><head attribute="value"><title>App</title></head><body></body></html>',
+    };
+
+    beforeEach(() => {
+      const mockRequest = {
+        continue: (fn) => fn(mockResponse),
+      };
+
+      global.cy.intercept.mock.calls[0][1](mockRequest);
+    });
+
+    it("should recognize the irregular head tag format and preserve it", () => {
+      expect(mockResponse.send).toHaveBeenCalledWith(
+        `<html><head attribute="value">${WEB_VITALS_SNIPPET}<title>App</title></head><body></body></html>`
+      );
+    });
+  });
+
   it("should visit the url without logging", () => {
     expect(global.cy.visit).toHaveBeenCalledWith(mockUrl, { log: false });
   });


### PR DESCRIPTION
# Issue

Fixes #1.

## Details

Change the search string for the head tag to be a regex, and the replace string to preserve any whitespace/attributes/values.

## CheckList

- [x] PR starts with [#_ISSUE_ID_].
- [x] Has been tested (where required).
