### PR TITLE
Converting the res object to a string

### DIFF
--- a/src/visitWithWebVitalsSnippet.js
+++ b/src/visitWithWebVitalsSnippet.js
@@ -3,7 +3,7 @@ const { WEB_VITALS_SNIPPET } = require("./constants");
 const visitWithWebVitalsSnippet = (url) => {
   cy.intercept(url, (req) => {
     req.continue((res) => {
-      const body = res.body.replace(
+      const body = res.body.toString().replace(
         /<head(>|.*?[^?]>)/g,
         `<head$1${WEB_VITALS_SNIPPET}`
       );


### PR DESCRIPTION
This fixed the TaylorMorrison replace error, and resolved the GoDaddy issue as well.

# Issue

Fixes #<4>.

## Details

Just converting the object to a String seemed to fix it on my end.

## CheckList

- [Yes] PR starts with [#_ISSUE_ID_].
- [Yes] Has been tested (where required).
