### PR TITLE
Fix typescript declarations

### DIFF
--- a/commands.d.ts
+++ b/commands.d.ts
@@ -66,6 +66,6 @@ declare namespace Cypress {
      * cy.vitals({ thresholds, url, selector });
      * @param {WebVitalsConfig} webVitalsConfig configuration
      */
-    vitals(webVitalsConfig: WebVitalsConfig);
+    vitals(webVitalsConfig?: WebVitalsConfig);
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/cmorten/cypress-web-vitals"
   },
   "main": "commands.js",
-  "types": "index.d.ts",
+  "types": "commands.d.ts",
   "scripts": {
     "ci": "yarn lint && yarn test",
     "lint": "eslint ./src ./examples",


### PR DESCRIPTION
# Issue

No open issue yet, this is a direct PR.

## Details

Thanks for this project, I like the idea of testing the web-vitals during the run of other end-to-end tests. This keeps our CI/CD pipeline configuration smaller.

During trying this project, I've spotted some typescript issues that this PR should fix.
Sorry for not opening 2 separate PRs... 🙏

---

1. The `package.json` links types to a not existing `index.d.ts`. This corrects the path using `commands.d.ts`. The first commit solves this issue. My cypress-only `tsconfig.e2e.json` now looks like this and works as expected:
```json
{
  "$schema": "https://json.schemastore.org/tsconfig.json",
  "compilerOptions": {
    "module": "CommonJS",
    "moduleResolution": "Node",
    "esModuleInterop": true,
    "resolveJsonModule": true,
    "target": "ES2015",
    "lib": ["ES2015", "DOM"],
    "types": [
      "cypress",
      "cypress-web-vitals"
    ]
  },
  "include": ["tests/cypress", "**/*.e2e.ts"]
}
```

2. The `webVitalsConfig` parameter in the type declaration file for `cy.vitals()` defines the parameter as required, but the commandHandler uses them as optional: https://github.com/cmorten/cypress-web-vitals/blob/main/src/vitalsCommandHandler.js#L16-L26. The second commit solves this issue.

## CheckList

- [ ] ~~PR starts with [#_ISSUE_ID_].~~
- [x] Has been tested (where required).
