### PR TITLE
[#27] Type `inp` as an optional threshold

### DIFF
--- a/commands.d.ts
+++ b/commands.d.ts
@@ -36,7 +36,7 @@ declare namespace Cypress {
      * Interaction to next paint.
      * @see https://web.dev/inp/
      */
-    inp: number | null;
+    inp?: number | null;
   }
 
   interface WebVitalsResults {

--- a/examples/10.x/cypress/e2e/custom.cy.js
+++ b/examples/10.x/cypress/e2e/custom.cy.js
@@ -9,6 +9,7 @@ describe("cy.vitals() command not using the defaults", () => {
         cls: 0.1,
         fcp: 1800,
         ttfb: 600,
+        inp: 500,
       },
     });
   });

--- a/examples/10.x/cypress/e2e/report.cy.js
+++ b/examples/10.x/cypress/e2e/report.cy.js
@@ -16,6 +16,7 @@ describe("cy.vitals() command not using the defaults", () => {
         expect(report.results).to.have.property("cls");
         expect(report.results).to.have.property("fcp");
         expect(report.results).to.have.property("ttfb");
+        expect(report.results).to.have.property("inp");
 
         cy.log("------ onReport values ------");
         cy.log(JSON.stringify(report, undefined, 2));

--- a/examples/12.x/cypress/e2e/custom.cy.js
+++ b/examples/12.x/cypress/e2e/custom.cy.js
@@ -9,6 +9,16 @@ describe("cy.vitals() command not using the defaults", () => {
         cls: 0.1,
         fcp: 1800,
         ttfb: 600,
+        inp: 500,
+      },
+    });
+  });
+
+  it("should meet the custom provided Web Vitals thresholds for a subset of vitals", () => {
+    cy.vitals({
+      url: "https://www.google.com/",
+      thresholds: {
+        lcp: 2500,
       },
     });
   });

--- a/examples/12.x/cypress/e2e/report.cy.js
+++ b/examples/12.x/cypress/e2e/report.cy.js
@@ -16,6 +16,7 @@ describe("cy.vitals() command not using the defaults", () => {
         expect(report.results).to.have.property("cls");
         expect(report.results).to.have.property("fcp");
         expect(report.results).to.have.property("ttfb");
+        expect(report.results).to.have.property("inp");
 
         cy.log("------ onReport values ------");
         cy.log(JSON.stringify(report, undefined, 2));

--- a/examples/9.x/cypress/integration/custom.test.js
+++ b/examples/9.x/cypress/integration/custom.test.js
@@ -9,6 +9,7 @@ describe("cy.vitals() command not using the defaults", () => {
         cls: 0.1,
         fcp: 1800,
         ttfb: 600,
+        inp: 500,
       },
     });
   });

--- a/examples/9.x/cypress/integration/report.test.js
+++ b/examples/9.x/cypress/integration/report.test.js
@@ -16,6 +16,7 @@ describe("cy.vitals() command not using the defaults", () => {
         expect(report.results).to.have.property("cls");
         expect(report.results).to.have.property("fcp");
         expect(report.results).to.have.property("ttfb");
+        expect(report.results).to.have.property("inp");
 
         cy.log("------ onReport values ------");
         cy.log(JSON.stringify(report, undefined, 2));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-web-vitals",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A Web Vitals command for cypress",
   "author": "Craig Morten <craig.morten@hotmail.co.uk>",
   "license": "MIT",


### PR DESCRIPTION
# Issue

Fixes #27.

## Details

All thresholds should be typed as optional including INP.

## CheckList

- [x] PR starts with [#_ISSUE_ID_].
- [x] Has been tested (where required).
